### PR TITLE
Add walletAddress to auth request

### DIFF
--- a/src/hedgehog.js
+++ b/src/hedgehog.js
@@ -42,7 +42,8 @@ class Hedgehog {
       const authData = {
         iv: ivHex,
         cipherText: cipherTextHex,
-        lookupKey: lookupKey
+        lookupKey: lookupKey,
+        walletAddress
       }
 
       const userData = {


### PR DESCRIPTION
This walletAddress is used in recaptcha scoring and tracking in identity service

https://github.com/AudiusProject/audius-protocol/pull/1242/files#diff-eff1edc5f4638d0675690b391f42a183c05de1aa4d2b46c503cb50e6aade390bR48