### PR TITLE
Remove old password auth record on password reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/hedgehog",
-  "version": "1.0.10",
+  "version": "1.0.9",
   "description": "A Metamask alternative that empowers you to build good UX",
   "browser": {
     "node-localstorage": false


### PR DESCRIPTION
Include old lookup key in call to setAuthFn if the old password is provided on password reset to allow implementers to mark old auth records as deleted.

Related: https://github.com/AudiusProject/audius-protocol/pull/1968