### PR TITLE
Add method to confirm user credentials

### DIFF
--- a/src/hedgehog.js
+++ b/src/hedgehog.js
@@ -134,13 +134,13 @@ class Hedgehog {
    * @returns {boolean} whether or not the credentials are valid for the current user
    */
   async confirmCredentials (username, password) {
-    let self = this
+    const self = this
 
     const existingEntropy = WalletManager.getEntropyFromLocalStorage()
     if (!existingEntropy) return false // not logged in yet
 
-    let lookupKey = await WalletManager.createAuthLookupKey(username, password)
-    let data = await self.getFn({ lookupKey })
+    const lookupKey = await WalletManager.createAuthLookupKey(username, password)
+    const data = await self.getFn({ lookupKey })
 
     if (data && data.iv && data.cipherText) {
       const { walletObj, entropy } = await WalletManager.decryptCipherTextAndRetrieveWallet(

--- a/src/walletManager.js
+++ b/src/walletManager.js
@@ -55,7 +55,6 @@ class WalletManager {
     // generated given the same username and password
     const ivHex = '0x4f7242b39969c3ac4c6712524d633ce9'
     const { keyHex } = await Authentication.createKey(username + ':::' + password, ivHex)
-    console.log(keyHex)
     return keyHex
   }
 

--- a/src/walletManager.js
+++ b/src/walletManager.js
@@ -55,7 +55,7 @@ class WalletManager {
     // generated given the same username and password
     const ivHex = '0x4f7242b39969c3ac4c6712524d633ce9'
     const { keyHex } = await Authentication.createKey(username + ':::' + password, ivHex)
-
+    console.log(keyHex)
     return keyHex
   }
 

--- a/tests/authenticationTest.js
+++ b/tests/authenticationTest.js
@@ -1,14 +1,14 @@
 const assert = require('assert')
 const { Authentication } = require('../index')
 
-const { PATH, ivHex, keyHex, entropy, password, cipherTextHex, addressStr } = require('./helpers')
+const { PATH, ivHex, keyHex, entropy, password, cipherTextHex, walletAddress } = require('./helpers')
 
 describe('Authentication', async function () {
   it('should create a wallet given entropy', async function () {
     const wallet = Authentication.generateWalletFromEntropy(entropy, PATH)
 
     // This address is deterministic given an entropy and path
-    assert.deepStrictEqual(wallet.getAddressString(), addressStr)
+    assert.deepStrictEqual(wallet.getAddressString(), walletAddress)
   })
 
   it('should generate a mnemonic and entropy', async function () {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -8,4 +8,8 @@ const addressStr = '0x7c47632073388ae968d30f6c060494fc0cfb4207'
 const lookupKey = '18c6f07f7b891bc5f2c79a20bd39f7971a499f3e7ada02cb2382d40e44661b92'
 const username = 'email@address.com'
 
-module.exports = { PATH, ivHex, keyHex, entropy, password, cipherTextHex, addressStr, lookupKey, username }
+const secondUserLookupKey = '06b52a1cadb6dacfd884eb05077283615089da28c6ebe6d46296742388e5e97a'
+const secondUserUsername = 'test@test2.com'
+const secondUserPassword = 'testpassword'
+
+module.exports = { PATH, ivHex, keyHex, entropy, password, cipherTextHex, addressStr, lookupKey, username, secondUserLookupKey, secondUserPassword, secondUserUsername }

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,15 +1,25 @@
 const PATH = "m/44'/60'/0'/0/0"
-const ivHex = 'e85bf7579aafe1554c6d0e5235a4a883'
-const keyHex = 'ef8457b244f144ba12afed55c8812da2898cea4331f9c53ed8eb791bba44aec5'
-const entropy = '62f6be1cb96587d7fd09808a0c095522'
-const password = 'testpassword'
-const cipherTextHex = '6b6cd020f0e50105fa4d7ba074c60f4b3f56a85739b734164fba6d30954d45f925ab5cd68a7c3d0270d58f8ee318d69b088998a4190c69b4692e45298a2fdb77'
-const addressStr = '0x7c47632073388ae968d30f6c060494fc0cfb4207'
-const lookupKey = '18c6f07f7b891bc5f2c79a20bd39f7971a499f3e7ada02cb2382d40e44661b92'
-const username = 'email@address.com'
 
-const secondUserLookupKey = '06b52a1cadb6dacfd884eb05077283615089da28c6ebe6d46296742388e5e97a'
-const secondUserUsername = 'test@test2.com'
-const secondUserPassword = 'testpassword'
+const users = [
+  {
+    username: 'email@address.com',
+    password: 'testpassword',
+    walletAddress: '0x7c47632073388ae968d30f6c060494fc0cfb4207',
+    lookupKey: '18c6f07f7b891bc5f2c79a20bd39f7971a499f3e7ada02cb2382d40e44661b92',
+    entropy: '62f6be1cb96587d7fd09808a0c095522',
+    ivHex: 'e85bf7579aafe1554c6d0e5235a4a883',
+    keyHex: 'ef8457b244f144ba12afed55c8812da2898cea4331f9c53ed8eb791bba44aec5',
+    cipherTextHex: '6b6cd020f0e50105fa4d7ba074c60f4b3f56a85739b734164fba6d30954d45f925ab5cd68a7c3d0270d58f8ee318d69b088998a4190c69b4692e45298a2fdb77'
+  },
+  {
+    username: 'test@test2.com',
+    password: 'testpassword',
+    walletAddress: '0x900dfaf7c2e68a7390eccbb200cd8322a9426a58',
+    lookupKey: '06b52a1cadb6dacfd884eb05077283615089da28c6ebe6d46296742388e5e97a',
+    ivHex: '52eda800b334f689c009ba0d7442adf3',
+    cipherTextHex: '0892a82c9e9e285c6bd4172b046bb827195d51000016ddcdd8c82895684636c0b8a8d5faae171704b871abfd39d52956a89911b4788087208b7e0c5b6ed642c9'
 
-module.exports = { PATH, ivHex, keyHex, entropy, password, cipherTextHex, addressStr, lookupKey, username, secondUserLookupKey, secondUserPassword, secondUserUsername }
+  }
+]
+
+module.exports = { PATH, users, ...users[0] }

--- a/tests/walletManagerTest.js
+++ b/tests/walletManagerTest.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const { WalletManager } = require('../index')
-const { entropy, addressStr } = require('./helpers')
+const { entropy, walletAddress } = require('./helpers')
 
 describe('WalletManager', async function () {
   it('should create a wallet ', async function () {
@@ -58,6 +58,6 @@ describe('WalletManager', async function () {
     let walletObj = WalletManager.getWalletObjFromLocalStorageIfExists()
 
     assert.notDeepStrictEqual(walletObj, null)
-    assert.deepStrictEqual(walletObj.getAddressString(), addressStr)
+    assert.deepStrictEqual(walletObj.getAddressString(), walletAddress)
   })
 })


### PR DESCRIPTION
The login method can't be used for a password confirmation, since entering in a un/pw of a different user won't error but instead log them into that user's account instead. This PR adds a new method for confirming the password of a user for those sensitive operations clients might have (eg updating user settings like email, password, username).