### PR TITLE
Propagate errors on reset password

### DIFF
--- a/src/hedgehog.js
+++ b/src/hedgehog.js
@@ -102,6 +102,7 @@ class Hedgehog {
       self.wallet = walletObj
     } catch (e) {
       self.logout()
+      throw e
     }
   }
 


### PR DESCRIPTION
Errors are being swallowed by hedgehog, which prevents consumers from knowing if the `setAuthData` succeeded or failed.

**NOTE**: Could break third party consumers calling this API without try/catch as it may now start throwing errors. However, I would consider this a bug fix as consumers should already expect that this can fail. Thoughts?