### PR TITLE
[C-718] Allow custom createKey

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,23 +6,23 @@
     "node-localstorage": false
   },
   "dependencies": {
-    "bip39": "^3.0.4",
-    "browserify-cipher": "^1.0.1",
-    "ethereumjs-wallet": "^1.0.2",
-    "node-localstorage": "^2.2.1",
-    "randombytes": "^2.1.0",
-    "safe-buffer": "^5.2.1"
+    "bip39": "3.0.4",
+    "browserify-cipher": "1.0.1",
+    "ethereumjs-wallet": "1.0.2",
+    "node-localstorage": "2.2.1",
+    "randombytes": "2.1.0",
+    "safe-buffer": "5.2.1"
   },
   "devDependencies": {
     "@tsconfig/node16-strictest": "1.0.3",
-    "@types/node": "^18.6.1",
-    "@types/randombytes": "^2.0.0",
-    "mocha": "^10.0.0",
-    "rollup": "^2.77.1",
-    "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-typescript2": "^0.32.1",
-    "standard": "^17.0.0",
-    "ts-mocha": "^10.0.0",
+    "@types/node": "18.6.1",
+    "@types/randombytes": "2.0.0",
+    "mocha": "10.0.0",
+    "rollup": "2.77.1",
+    "rollup-plugin-copy": "3.4.0",
+    "rollup-plugin-typescript2": "0.32.1",
+    "standard": "17.0.0",
+    "ts-mocha": "10.0.0",
     "typescript": "4.7.4"
   },
   "main": "dist/index.js",
@@ -32,17 +32,6 @@
     "lint:fix": "npm run lint -- --fix",
     "typecheck": "tsc",
     "test": "ts-mocha tests"
-  },
-  "standard": {
-    "globals": [
-      "Blob",
-      "self",
-      "Worker",
-      "postMessage",
-      "describe",
-      "it",
-      "beforeEach"
-    ]
   },
   "author": "",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,17 @@
     "typecheck": "tsc",
     "test": "ts-mocha tests"
   },
+  "standard": {
+    "globals": [
+      "Blob",
+      "self",
+      "Worker",
+      "postMessage",
+      "describe",
+      "it",
+      "beforeEach"
+    ]
+  },
   "author": "",
   "license": "MIT"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
 export * from "./Hedgehog";
 export * from "./WalletManager";
 export * from "./Authentication";
-export type { LocalStorage } from "./types";
+export * from "./utils";
+export type {
+  GetFn,
+  SetAuthFn,
+  SetUserFn,
+  LocalStorage,
+  CreateKey,
+  PrivateKey,
+} from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,3 +3,27 @@ export type LocalStorage = {
   setItem: (key: string, value: string) => Promise<void> | void;
   removeItem: (key: string) => Promise<void> | void;
 };
+
+export type CreateKey = (
+  encryptStr: string,
+  ivHex: string
+) => Promise<PrivateKey>;
+
+export type PrivateKey = { keyHex: string; keyBuffer: Uint8Array };
+
+export type GetFn = (params: {
+  lookupKey: string;
+}) =>
+  | Promise<{ iv: string; cipherText: string }>
+  | { iv: string; cipherText: string };
+
+export type SetAuthFn = (params: {
+  iv: string;
+  cipherText: string;
+  lookupKey: string;
+}) => any | Promise<any>;
+
+export type SetUserFn = (params: {
+  walletAddress: string;
+  username: string;
+}) => any | Promise<any>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import crypto from "crypto";
-import { resolve } from "path";
 import type { PrivateKey } from "./types";
 
 // https://stackoverflow.com/questions/38987784/how-to-convert-a-hexadecimal-string-to-uint8array-and-back-in-javascript

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
-// helpers to convert buffer to and from hex strings
+import crypto from "crypto";
+import type { PrivateKey } from "./types";
+
 // https://stackoverflow.com/questions/38987784/how-to-convert-a-hexadecimal-string-to-uint8array-and-back-in-javascript
 export function bufferFromHexString(hexString: string) {
   const byteArray = hexString
@@ -19,13 +21,91 @@ export function WebWorker(worker: Worker) {
  * Fallback for localStorage that works in node and the browser
  */
 export function getPlatformLocalStorage() {
-  if (typeof window === "undefined" || window === null) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
+  if (isNodeEnv()) {
     const LocalStorage = require("node-localstorage").LocalStorage;
     return new LocalStorage("./local-storage");
-  } else {
+  }
+  if (isWebEnv()) {
     return window.localStorage;
   }
+  throw new Error(
+    "Please pass in valid localStorage object into the Hedgehog constructor"
+  );
+}
+
+function isReactNativeEnv() {
+  return (
+    typeof navigator !== "undefined" && navigator.product === "ReactNative"
+  );
+}
+
+function isWebEnv() {
+  return (
+    typeof window !== "undefined" &&
+    window &&
+    window.Worker &&
+    !isReactNativeEnv()
+  );
+}
+
+function isNodeEnv() {
+  return typeof window === "undefined" || window === null;
+}
+
+export function getPlatformCreateKey() {
+  /**
+   * Given a user encryptStr and initialization vector, generate a private key
+   * @param encryptStr String to encrypt (can be user password or some kind of lookup key)
+   * @param ivHex hex string iv value
+   */
+  const createKey = async (encryptStr: string, ivHex: string) => {
+    return new Promise<PrivateKey>((resolve, reject) => {
+      if (isWebEnv()) {
+        const worker = WebWorker(require("./authWorker.js").toString());
+        worker.postMessage(JSON.stringify({ encryptStr, ivHex }));
+
+        worker.onmessage = (event) => {
+          resolve(event.data);
+        };
+      } else if (isNodeEnv()) {
+        const N = 32768;
+        const r = 8;
+        const p = 1;
+        const dkLen = 32;
+        const encryptStrBuffer = Buffer.from(encryptStr);
+        const ivBuffer = Buffer.from(ivHex);
+        // https://github.com/nodejs/node/issues/21524#issuecomment-400012811
+        const maxmem = 128 * p * r + 128 * (2 + N) * r;
+
+        crypto.scrypt(
+          encryptStrBuffer,
+          ivBuffer,
+          dkLen,
+          { N, r, p, maxmem },
+          (err, derivedKey) => {
+            if (err) {
+              reject(err);
+            } else {
+              const keyHex = derivedKey.toString("hex");
+
+              // This is the private key
+              let keyBuffer = bufferFromHexString(keyHex);
+
+              resolve({ keyHex, keyBuffer });
+            }
+          }
+        );
+      } else {
+        reject(
+          new Error(
+            "Please pass in valid createKey function into the Hedgehog constructor"
+          )
+        );
+      }
+    });
+  };
+
+  return createKey;
 }
 
 export function waitUntil(condition: () => boolean) {

--- a/tests/authenticationTest.js
+++ b/tests/authenticationTest.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const { Authentication } = require('../src')
+const { Authentication, getPlatformCreateKey } = require('../src')
 
 const {
   PATH,
@@ -10,6 +10,8 @@ const {
   cipherTextHex,
   walletAddress
 } = require('./helpers')
+
+const createKey = getPlatformCreateKey()
 
 describe('Authentication', async function () {
   it('should create a wallet given entropy', async function () {
@@ -38,7 +40,7 @@ describe('Authentication', async function () {
 
   it('should create a key', async function () {
     this.timeout(15000)
-    const key = await Authentication.createKey(password, ivHex)
+    const key = await createKey(password, ivHex)
 
     assert.deepStrictEqual(key.keyHex, keyHex)
   })

--- a/tests/walletManagerTest.js
+++ b/tests/walletManagerTest.js
@@ -1,7 +1,9 @@
 const assert = require('assert')
-const { WalletManager } = require('../src')
+const { WalletManager, getPlatformCreateKey } = require('../src')
 const { entropy, walletAddress } = require('./helpers')
 const { LocalStorage } = require('node-localstorage')
+
+const createKey = getPlatformCreateKey()
 
 describe('WalletManager', async function () {
   it('should create a wallet ', async function () {
@@ -10,7 +12,8 @@ describe('WalletManager', async function () {
     const data = await WalletManager.createWalletObj(
       'testpassword',
       undefined,
-      localStorage
+      localStorage,
+      createKey
     )
 
     assert.notDeepStrictEqual(data.ivHex, null)
@@ -26,14 +29,17 @@ describe('WalletManager', async function () {
     const data = await WalletManager.createWalletObj(
       'testpassword',
       undefined,
-      localStorage
+      localStorage,
+      createKey
     )
 
-    const decryptedData = await WalletManager.decryptCipherTextAndRetrieveWallet(
-      'testpassword',
-      data.ivHex,
-      data.cipherTextHex
-    )
+    const decryptedData =
+      await WalletManager.decryptCipherTextAndRetrieveWallet(
+        'testpassword',
+        data.ivHex,
+        data.cipherTextHex,
+        createKey
+      )
     assert.deepStrictEqual(decryptedData.entropy, data.entropy)
     assert.notDeepStrictEqual(decryptedData.walletObj, null)
   })
@@ -44,14 +50,16 @@ describe('WalletManager', async function () {
     const data = await WalletManager.createWalletObj(
       'testpassword',
       undefined,
-      localStorage
+      localStorage,
+      createKey
     )
 
     try {
       await WalletManager.decryptCipherTextAndRetrieveWallet(
         'testpassword2',
         data.ivHex,
-        data.cipherTextHex
+        data.cipherTextHex,
+        createKey
       )
 
       assert.fail(
@@ -75,7 +83,7 @@ describe('WalletManager', async function () {
     assert.deepStrictEqual(res2, entropy)
   })
 
-  it('should check that we can\'t retrieve a wallet from localhost if entropy is null', async function () {
+  it("should check that we can't retrieve a wallet from localhost if entropy is null", async function () {
     const localStorage = new LocalStorage('./local-storage')
     await WalletManager.deleteEntropyFromLocalStorage(localStorage)
     const walletObj = await WalletManager.getWalletObjFromLocalStorageIfExists(


### PR DESCRIPTION
Allows custom createKey function to be provided, which is necessary for react-native to run hedgehog (which needs a special scrypt library)

Decided to allow createKey to be provided instead of just scrypt since each implementation varies pretty dramatically