### PR TITLE
breaking: Use object args everywhere and allow for optional parameters

### DIFF
--- a/src/Hedgehog.ts
+++ b/src/Hedgehog.ts
@@ -1,10 +1,12 @@
 import type Wallet from "ethereumjs-wallet";
 import type {
+  ChangeCredentialsArgs,
   CreateKey,
   GetFn,
   LocalStorage,
   SetAuthFn,
   SetUserFn,
+  LoginArgs,
 } from "./types";
 import {
   getPlatformCreateKey,
@@ -77,19 +79,9 @@ export class Hedgehog {
   /**
    * Given user credentials, create a client side wallet and all other authentication artifacts,
    * call setFn to persist the artifacts to a server and return the wallet object
-   * @param username username
-   * @param password user password
    * @returns ethereumjs-wallet wallet object
    */
-  async signUp({
-    username,
-    password,
-    ...optionalParams
-  }: {
-    username: string;
-    password: string;
-    [key: string]: unknown;
-  }) {
+  async signUp({ username, password, ...optionalParams }: LoginArgs) {
     let self = this;
 
     const createWalletPromise = WalletManager.createWalletObj(
@@ -143,18 +135,8 @@ export class Hedgehog {
   /**
    * Generate new set of auth credentials to allow login
    * If the old password is included, the setAuthFn will include the old lookup key for deletion
-   * @param username - username
-   * @param password - new password
    */
-  async resetPassword({
-    username,
-    password,
-    ...optionalParams
-  }: {
-    username: string;
-    password: string;
-    [key: string]: unknown;
-  }) {
+  async resetPassword({ username, password, ...optionalParams }: LoginArgs) {
     let self = this;
     let entropy = await WalletManager.getEntropyFromLocalStorage(
       this.localStorage
@@ -202,23 +184,14 @@ export class Hedgehog {
   /**
    * Generate new set of auth credentials to allow login and remove the old credentials
    * Note: Doesn't log out on error
-   * @param newUsername - username
-   * @param newPassword - new password
-   * @param oldPassword - old password
    */
-  async updateCredentials({
+  async changeCredentials({
     newUsername,
     newPassword,
     oldUsername,
     oldPassword,
     ...optionalParams
-  }: {
-    newUsername: string;
-    newPassword: string;
-    oldUsername: string;
-    oldPassword: string;
-    [key: string]: unknown;
-  }) {
+  }: ChangeCredentialsArgs) {
     let self = this;
     let entropy = await WalletManager.getEntropyFromLocalStorage(
       this.localStorage
@@ -272,19 +245,9 @@ export class Hedgehog {
   /**
    * Given user credentials, attempt to get authentication artifacts from server using
    * getFn, create the private key using the artifacts and the user password
-   * @param username username
-   * @param password user password
    * @returns ethereumjs-wallet wallet object
    */
-  async login({
-    username,
-    password,
-    ...optionalParams
-  }: {
-    username: string;
-    password: string;
-    [key: string]: unknown;
-  }) {
+  async login({ username, password, ...optionalParams }: LoginArgs) {
     let self = this;
     let lookupKey = await WalletManager.createAuthLookupKey(
       username,
@@ -315,19 +278,13 @@ export class Hedgehog {
 
   /**
    * Confirms the user credentials given generate the same entropy after using artifacts from the server
-   * @param username username
-   * @param password user password
    * @returns whether or not the credentials are valid for the current user
    */
   async confirmCredentials({
     username,
     password,
     ...optionalParams
-  }: {
-    username: string;
-    password: string;
-    [key: string]: unknown;
-  }) {
+  }: LoginArgs) {
     const self = this;
 
     const existingEntropy = await WalletManager.getEntropyFromLocalStorage(

--- a/src/Hedgehog.ts
+++ b/src/Hedgehog.ts
@@ -81,7 +81,15 @@ export class Hedgehog {
    * @param password user password
    * @returns ethereumjs-wallet wallet object
    */
-  async signUp(username: string, password: string) {
+  async signUp({
+    username,
+    password,
+    ...optionalParams
+  }: {
+    username: string;
+    password: string;
+    [key: string]: unknown;
+  }) {
     let self = this;
 
     const createWalletPromise = WalletManager.createWalletObj(
@@ -108,12 +116,14 @@ export class Hedgehog {
       const walletAddress = walletObj.getAddressString();
 
       const authData = {
+        ...optionalParams,
         iv: ivHex,
         cipherText: cipherTextHex,
         lookupKey: lookupKey,
       };
 
       const userData = {
+        ...optionalParams,
         username: username,
         walletAddress: walletAddress,
       };
@@ -136,7 +146,15 @@ export class Hedgehog {
    * @param username - username
    * @param password - new password
    */
-  async resetPassword(username: string, password: string) {
+  async resetPassword({
+    username,
+    password,
+    ...optionalParams
+  }: {
+    username: string;
+    password: string;
+    [key: string]: unknown;
+  }) {
     let self = this;
     let entropy = await WalletManager.getEntropyFromLocalStorage(
       this.localStorage
@@ -167,6 +185,7 @@ export class Hedgehog {
       const { ivHex, cipherTextHex, walletObj } = walletResult;
 
       const authData = {
+        ...optionalParams,
         iv: ivHex,
         cipherText: cipherTextHex,
         lookupKey: lookupKey,
@@ -181,17 +200,25 @@ export class Hedgehog {
   }
 
   /**
-   * Generate new set of auth credentials to allow login and remove the old password
+   * Generate new set of auth credentials to allow login and remove the old credentials
    * Note: Doesn't log out on error
-   * @param username - username
-   * @param password - new password
+   * @param newUsername - username
+   * @param newPassword - new password
    * @param oldPassword - old password
    */
-  async changePassword(
-    username: string,
-    password: string,
-    oldPassword: string
-  ) {
+  async updateCredentials({
+    newUsername,
+    newPassword,
+    oldUsername,
+    oldPassword,
+    ...optionalParams
+  }: {
+    newUsername: string;
+    newPassword: string;
+    oldUsername: string;
+    oldPassword: string;
+    [key: string]: unknown;
+  }) {
     let self = this;
     let entropy = await WalletManager.getEntropyFromLocalStorage(
       this.localStorage
@@ -201,18 +228,18 @@ export class Hedgehog {
     }
 
     const createWalletPromise = WalletManager.createWalletObj(
-      password,
+      newPassword,
       entropy,
       this.localStorage,
       this.createKey
     );
     const lookupKeyPromise = WalletManager.createAuthLookupKey(
-      username,
-      password,
+      newUsername,
+      newPassword,
       this.createKey
     );
     const oldLookupKeyPromise = WalletManager.createAuthLookupKey(
-      username,
+      oldUsername !== undefined ? oldUsername : newUsername,
       oldPassword,
       this.createKey
     );
@@ -228,6 +255,7 @@ export class Hedgehog {
       const { ivHex, cipherTextHex, walletObj } = walletResult;
 
       const authData = {
+        ...optionalParams,
         iv: ivHex,
         cipherText: cipherTextHex,
         lookupKey: lookupKey,
@@ -248,14 +276,22 @@ export class Hedgehog {
    * @param password user password
    * @returns ethereumjs-wallet wallet object
    */
-  async login(username: string, password: string) {
+  async login({
+    username,
+    password,
+    ...optionalParams
+  }: {
+    username: string;
+    password: string;
+    [key: string]: unknown;
+  }) {
     let self = this;
     let lookupKey = await WalletManager.createAuthLookupKey(
       username,
       password,
       this.createKey
     );
-    let data = await self.getFn({ lookupKey });
+    let data = await self.getFn({ ...optionalParams, lookupKey });
 
     if (data && data.iv && data.cipherText) {
       const { walletObj, entropy } =
@@ -283,7 +319,15 @@ export class Hedgehog {
    * @param password user password
    * @returns whether or not the credentials are valid for the current user
    */
-  async confirmCredentials(username: string, password: string) {
+  async confirmCredentials({
+    username,
+    password,
+    ...optionalParams
+  }: {
+    username: string;
+    password: string;
+    [key: string]: unknown;
+  }) {
     const self = this;
 
     const existingEntropy = await WalletManager.getEntropyFromLocalStorage(
@@ -296,7 +340,7 @@ export class Hedgehog {
       password,
       this.createKey
     );
-    const data = await self.getFn({ lookupKey });
+    const data = await self.getFn({ ...optionalParams, lookupKey });
 
     if (data && data.iv && data.cipherText) {
       const { walletObj, entropy } =

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export type PrivateKey = { keyHex: string; keyBuffer: Uint8Array };
 
 export type GetFn = (params: {
   lookupKey: string;
+  [key: string]: unknown;
 }) =>
   | Promise<{ iv: string; cipherText: string }>
   | { iv: string; cipherText: string };
@@ -21,9 +22,12 @@ export type SetAuthFn = (params: {
   iv: string;
   cipherText: string;
   lookupKey: string;
+  oldLookupKey?: string;
+  [key: string]: unknown;
 }) => any | Promise<any>;
 
 export type SetUserFn = (params: {
   walletAddress: string;
   username: string;
+  [key: string]: unknown;
 }) => any | Promise<any>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,3 +31,17 @@ export type SetUserFn = (params: {
   username: string;
   [key: string]: unknown;
 }) => any | Promise<any>;
+
+export type LoginArgs = {
+  username: string;
+  password: string;
+  [key: string]: unknown;
+};
+
+export type ChangeCredentialsArgs = {
+  newUsername: string;
+  newPassword: string;
+  oldUsername: string;
+  oldPassword: string;
+  [key: string]: unknown;
+};

--- a/tests/hedgehogTest.js
+++ b/tests/hedgehogTest.js
@@ -76,7 +76,7 @@ describe('Hedgehog', async function () {
     resetDataInDB()
 
     try {
-      await hh.login(username, password)
+      await hh.login({ username, password })
       assert.fail("Should not login if there's non user record")
     } catch (e) {
       assert.deepStrictEqual(1, 1)
@@ -88,7 +88,7 @@ describe('Hedgehog', async function () {
     this.timeout(15000)
     resetDataInDB()
 
-    const walletObj = await hh.signUp(username, password)
+    const walletObj = await hh.signUp({ username, password })
     assert.notDeepStrictEqual(walletObj.getAddressString(), null)
 
     assert.deepStrictEqual(hh.isLoggedIn(), true)
@@ -99,7 +99,7 @@ describe('Hedgehog', async function () {
     this.timeout(15000)
     setDataInDB(authValues, userValues)
 
-    const walletObj = await hh.login(username, password)
+    const walletObj = await hh.login({ username, password })
     assert.notDeepStrictEqual(walletObj.getAddressString(), null)
     assert.deepStrictEqual(hh.isLoggedIn(), true)
     assert.deepStrictEqual(hh.getWallet(), walletObj)
@@ -114,12 +114,12 @@ describe('Hedgehog', async function () {
     setDataInDB(authValues, userValues)
     await hh.login(username, password)
     assert.strictEqual(
-      await hh.confirmCredentials(username, password + '~'),
+      await hh.confirmCredentials({ username, password: password + '~' }),
       false,
       'credentials should not confirm - wrong password'
     )
     assert.strictEqual(
-      await hh.confirmCredentials(username, password),
+      await hh.confirmCredentials({ username, password }),
       true,
       'credentials should confirm'
     )
@@ -128,7 +128,7 @@ describe('Hedgehog', async function () {
   it('should fail credential confirmation as not logged in', async function () {
     this.timeout(15000)
     assert.strictEqual(
-      await hh.confirmCredentials(username, password),
+      await hh.confirmCredentials({ username, password }),
       false,
       'credentials should not confirm - not logged in'
     )
@@ -137,7 +137,7 @@ describe('Hedgehog', async function () {
   it('should fail credential confirmation as the credentials are for the wrong user', async function () {
     this.timeout(15000)
     setDataInDB(authValues, userValues)
-    await hh.login(username, password)
+    await hh.login({ username, password })
     setDataInDB(
       {
         iv: users[1].ivHex,
@@ -147,8 +147,10 @@ describe('Hedgehog', async function () {
       { walletAddress: users[1].walletAddress, username: users[1].username }
     )
     const result = await hh.confirmCredentials(
-      users[1].username,
-      users[1].password
+      {
+        username: users[1].username,
+        password: users[1].password
+      }
     )
     assert.strictEqual(
       result,

--- a/tests/hedgehogTest.js
+++ b/tests/hedgehogTest.js
@@ -112,7 +112,7 @@ describe('Hedgehog', async function () {
   it('should log in and fail one credential confirmation and pass the other', async function () {
     this.timeout(15000)
     setDataInDB(authValues, userValues)
-    await hh.login(username, password)
+    await hh.login({ username, password })
     assert.strictEqual(
       await hh.confirmCredentials({ username, password: password + '~' }),
       false,


### PR DESCRIPTION
Fast way to unblock us from extending Hedgehog to add any sort of optional server side logic like OTP, TOTP, etc.

Merging to a `release-v2.0.0` branch which I'll release as various prerelease alpha versions to NPM